### PR TITLE
Going back to old ZLib implementation for JS & WASM

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,11 +57,19 @@ detekt {
     config.setFrom("detekt.yml")
     allRules = true
     parallel = true
+    ignoreFailures = false
 }
 
 kotlin {
 
     explicitApi()
+
+    /* Make the code safer */
+    compilerOptions {
+        progressiveMode = true
+        extraWarnings = true
+        allWarningsAsErrors = true
+    }
 
     android {
 

--- a/src/androidMain/kotlin/de/stefan_oltmann/kim/android/ContentResolverExtensions.kt
+++ b/src/androidMain/kotlin/de/stefan_oltmann/kim/android/ContentResolverExtensions.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/androidMain/kotlin/de/stefan_oltmann/kim/common/ZLib.android.kt
+++ b/src/androidMain/kotlin/de/stefan_oltmann/kim/common/ZLib.android.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/common/ByteArrayExtensions.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/common/ByteArrayExtensions.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/common/FourCC.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/common/FourCC.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/common/Latin1EncodingExtensions.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/common/Latin1EncodingExtensions.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/common/LocalDateTimeExtensions.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/common/LocalDateTimeExtensions.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/common/RationalNumbers.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/common/RationalNumbers.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/common/ZLib.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/common/ZLib.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/MediaFormatMagicNumbers.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/MediaFormatMagicNumbers.kt
@@ -1,6 +1,6 @@
 /*
- * Copyright 2026 Ramon Bouckaert
  * Copyright 2026 Stefan Oltmann
+ * Copyright 2026 Ramon Bouckaert
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/MediaMetadata.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/MediaMetadata.kt
@@ -38,11 +38,11 @@ public class MediaMetadata internal constructor(
 
     public fun findStringValue(tagInfo: TagInfo): String? {
 
-        val strings = findTiffField(tagInfo)?.value as? List<String>
+        val strings = findTiffField(tagInfo)?.value as? List<*>
 
         /* Looks like Canon and Fuji OOC JPEGs have lens make in an array.  */
         if (!strings.isNullOrEmpty())
-            return strings.first()
+            return strings.first() as? String
 
         return findTiffField(tagInfo)?.value as? String
     }

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/BaseMediaFileFormatImageParser.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/BaseMediaFileFormatImageParser.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2026 Ramon Bouckaert
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/BoxReader.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/BoxReader.kt
@@ -1,6 +1,6 @@
 /*
- * Copyright 2026 Ramon Bouckaert
  * Copyright 2026 Stefan Oltmann
+ * Copyright 2026 Ramon Bouckaert
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2002-2023 Drew Noakes and contributors
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/BoxType.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/BoxType.kt
@@ -1,6 +1,6 @@
 /*
- * Copyright 2026 Ramon Bouckaert
  * Copyright 2026 Stefan Oltmann
+ * Copyright 2026 Ramon Bouckaert
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/CopyByteReader.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/CopyByteReader.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/box/MediaBox.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/box/MediaBox.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2026 Ramon Bouckaert
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2002-2023 Drew Noakes and contributors

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/box/MediaDataBox.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/box/MediaDataBox.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2002-2023 Drew Noakes and contributors
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/box/MetaBoxTopLevel.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/box/MetaBoxTopLevel.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2026 Ramon Bouckaert
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/box/MovieBox.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/box/MovieBox.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2026 Ramon Bouckaert
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2002-2023 Drew Noakes and contributors

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/box/TrackBox.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/box/TrackBox.kt
@@ -1,6 +1,6 @@
 /*
- * Copyright 2026 Ramon Bouckaert
  * Copyright 2026 Stefan Oltmann
+ * Copyright 2026 Ramon Bouckaert
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2002-2023 Drew Noakes and contributors
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/cr3/Cr3PreviewExtractor.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/cr3/Cr3PreviewExtractor.kt
@@ -118,8 +118,6 @@ public object Cr3PreviewExtractor {
 
             val type = BoxType.of(typeBytes)
 
-            position += headerLength
-
             when (size) {
 
                 0L -> size = available // The last box extends to the end of the file.
@@ -132,11 +130,10 @@ public object Cr3PreviewExtractor {
                     val LARGE_SIZE_FIELD_LENGTH = 8L
 
                     headerLength += LARGE_SIZE_FIELD_LENGTH
-                    position += LARGE_SIZE_FIELD_LENGTH
                 }
             }
 
-            if (size <= 0 || size > available)
+            if (size !in 1..available)
                 throw ImageReadException("Box $type has an invalid size: $size.")
 
             val dataSize = (size - headerLength).toInt()
@@ -190,8 +187,9 @@ public object Cr3PreviewExtractor {
 
                             byteReader.skipBytes(
                                 "mdat tail",
-                                (dataSize - relativeOffset - windowLength).toLong()
+                                (dataSize - relativeOffset - windowLength)
                             )
+
                         } else {
 
                             byteReader.skipBytes("mdat data", dataSize.toLong())

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/cr3/Cr3Reader.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/cr3/Cr3Reader.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/JpegRewriter.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/JpegRewriter.kt
@@ -210,8 +210,8 @@ public object JpegRewriter {
             writeSegments(
                 byteWriter = outputWriter,
                 segments = insertAfterLastAppSegments(
-                    segments.filterNot { piece -> piece is JFIFPieceSegment && piece.isIptcSegment() },
-                    createIptcSegments(metadata)
+                    segments = segments.filterNot { piece -> piece.isIptcSegment() },
+                    newSegments = createIptcSegments(metadata)
                 )
             )
         }
@@ -232,7 +232,7 @@ public object JpegRewriter {
         val mergedBlocks = metadata.nonIptcBlocks + newBlock
 
         return createApp13Segments(
-            IptcWriter.writeIptcBlocks(mergedBlocks, includeApp13Identifier = false)
+            photoshopData = IptcWriter.writeIptcBlocks(mergedBlocks, includeApp13Identifier = false)
         )
     }
 
@@ -291,10 +291,8 @@ public object JpegRewriter {
             writeSegments(
                 byteWriter = outputWriter,
                 segments = insertAfterLastAppSegments(
-                    segments.filterNot { segment ->
-                        segment is JFIFPieceSegment && segment.isXmpSegment()
-                    },
-                    createXmpSegments(xmpXml)
+                    segments = segments.filterNot { segment -> segment.isXmpSegment() },
+                    newSegments = createXmpSegments(xmpXml)
                 )
             )
         }

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/iptc/IptcBlock.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/iptc/IptcBlock.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/iptc/IptcParser.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/iptc/IptcParser.kt
@@ -218,7 +218,7 @@ public object IptcParser {
 
             val blockNameLength = byteReader.readByte("block name length").toInt()
 
-            var blockNameBytes: ByteArray
+            val blockNameBytes: ByteArray
 
             if (blockNameLength == 0) {
 

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/iptc/IptcTypes.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/iptc/IptcTypes.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/jfif/JFIFPiece.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/jfif/JFIFPiece.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/jfif/JFIFPieceSegment.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/jfif/JFIFPieceSegment.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/jfif/JFIFPieceSegmentExif.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/jfif/JFIFPieceSegmentExif.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/segment/AppnSegment.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/segment/AppnSegment.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/segment/GenericSegment.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/segment/GenericSegment.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/segment/JfifSegment.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/segment/JfifSegment.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/segment/Segment.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/segment/Segment.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/segment/SofnSegment.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/segment/SofnSegment.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/segment/UnknownSegment.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/segment/UnknownSegment.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/xmp/JpegXmpParser.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/xmp/JpegXmpParser.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jxl/JxlReader.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jxl/JxlReader.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/png/PngCrc.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/png/PngCrc.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/png/PngUpdater.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/png/PngUpdater.kt
@@ -88,7 +88,7 @@ internal object PngUpdater : MetadataUpdater {
             StaleChunkFilter { chunkType, keyword ->
                 (exifBytes != null &&
                     (chunkType == PngChunkType.EXIF || keyword == PngConstants.EXIF_KEYWORD)) ||
-                    (updatedXmp != null && keyword == PngConstants.XMP_KEYWORD)
+                    (keyword == PngConstants.XMP_KEYWORD)
             }
         }
     }

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/constant/GeoTiffTag.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/constant/GeoTiffTag.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/constant/TiffTag.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/constant/TiffTag.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeAscii.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeAscii.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeByte.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeByte.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeDouble.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeDouble.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeFloat.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeFloat.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeLong.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeLong.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeRational.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeRational.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeSByte.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeSByte.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeSLong.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeSLong.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeSRational.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeSRational.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeSShort.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeSShort.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeShort.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeShort.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeUndefined.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/fieldtype/FieldTypeUndefined.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/geotiff/GeoKey.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/geotiff/GeoKey.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/geotiff/GeoTiffDirectory.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/geotiff/GeoTiffDirectory.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/makernote/apple/AppleMakerNoteHandler.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/makernote/apple/AppleMakerNoteHandler.kt
@@ -222,8 +222,6 @@ internal object AppleMakerNoteHandler : MakerNoteHandler() {
             if (keyEnd > blobSize)
                 return
 
-            val key = blob.copyOfRange(keyOffset.toInt() + 1, keyEnd.toInt()).decodeToString()
-
             val valueMarker = byteAt(valueOffset) ?: return
 
             if (valueMarker and 0xF0 != 0x10)

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/makernote/nikon/NikonDecryptor.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/makernote/nikon/NikonDecryptor.kt
@@ -119,7 +119,7 @@ internal object NikonDecryptor {
         for (shift in 0..3)
             key = key xor ((count shr (shift * 8)) and 0xff)
 
-        var ci0 = xlat[0][serialKey and 0xff]
+        val ci0 = xlat[0][serialKey and 0xff]
         var cj = xlat[1][key]
         var ck = 0x60
 

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/taginfo/TagInfoGpsText.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/taginfo/TagInfoGpsText.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/write/TiffOffsetItem.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/write/TiffOffsetItem.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/write/TiffOffsetItems.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/tiff/write/TiffOffsetItems.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/webp/chunk/ImageSizeAware.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/webp/chunk/ImageSizeAware.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/xmp/XmpReader.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/xmp/XmpReader.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/input/ByteArrayByteReader.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/input/ByteArrayByteReader.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/input/DefaultRandomAccessByteReader.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/input/DefaultRandomAccessByteReader.kt
@@ -124,7 +124,7 @@ public class DefaultRandomAccessByteReader(
         return buffer.copyOfRange(offset, minOf(endIndex, bufferPosition))
     }
 
-    override fun close(): Unit {
+    override fun close() {
 
         /* Free the buffered file prefix as soon as possible. */
         buffer = ByteArray(0)

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/input/PrePendingByteReader.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/input/PrePendingByteReader.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/input/RandomAccessByteReader.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/input/RandomAccessByteReader.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/model/MediaFormat.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/model/MediaFormat.kt
@@ -1,6 +1,6 @@
 /*
- * Copyright 2026 Ramon Bouckaert
  * Copyright 2026 Stefan Oltmann
+ * Copyright 2026 Ramon Bouckaert
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/output/BigEndianBinaryByteWriter.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/output/BigEndianBinaryByteWriter.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/output/BufferByteWriter.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/output/BufferByteWriter.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/output/LittleEndianBinaryByteWriter.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/output/LittleEndianBinaryByteWriter.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  * Copyright 2007-2023 The Apache Software Foundation
  *

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/PreviewImageExtractionTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/PreviewImageExtractionTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/XmpExtractionTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/XmpExtractionTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/common/ByteArrayExtensionsTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/common/ByteArrayExtensionsTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/common/ExifDateUtilTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/common/ExifDateUtilTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/common/KimValueFormatterTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/common/KimValueFormatterTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/common/KotlinIoExtensions.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/common/KotlinIoExtensions.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/common/Latin1EncodingTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/common/Latin1EncodingTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/common/LocalDateTimeExtensionsTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/common/LocalDateTimeExtensionsTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/format/bmff/BaseMediaFileFormatImageParserTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/format/bmff/BaseMediaFileFormatImageParserTest.kt
@@ -265,7 +265,7 @@ class BaseMediaFileFormatImageParserTest {
 
             for (extent in item.extents) {
                 writer.writeInt(extent.offset.toInt(), BMFF_BYTE_ORDER)
-                writer.writeInt(extent.length.toInt(), BMFF_BYTE_ORDER)
+                writer.writeInt(extent.length, BMFF_BYTE_ORDER)
             }
         }
 

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/format/gif/GifMetadataExtractorTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/format/gif/GifMetadataExtractorTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ramon Bouckaert
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/format/gif/chunk/GifChunkImageDescriptorTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/format/gif/chunk/GifChunkImageDescriptorTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ramon Bouckaert
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/format/gif/chunk/GifChunkLogicalScreenDescriptorTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/format/gif/chunk/GifChunkLogicalScreenDescriptorTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ramon Bouckaert
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/format/jpeg/ExifThumbnailExtractionTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/format/jpeg/ExifThumbnailExtractionTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/format/jpeg/iptc/IptcTestConstants.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/format/jpeg/iptc/IptcTestConstants.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/format/png/PngImageParserTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/format/png/PngImageParserTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/format/png/PngMetadataExtractorTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/format/png/PngMetadataExtractorTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/format/raf/RafMetadataExtractorTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/format/raf/RafMetadataExtractorTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/format/tiff/FujiFilmTagTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/format/tiff/FujiFilmTagTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2026 Gnod
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/format/tiff/makernote/BrokenMakerNoteTiff.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/format/tiff/makernote/BrokenMakerNoteTiff.kt
@@ -109,7 +109,7 @@ internal object BrokenMakerNoteTiff {
         imageData.copyInto(bytes, pos)
         pos += imageData.size
         bytes[pos++] = 0xff.toByte() // EOI
-        bytes[pos++] = 0xd9.toByte()
+        bytes[pos] = 0xd9.toByte()
 
         return bytes
     }

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/format/webp/chunk/WebPChunkVP8XTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/format/webp/chunk/WebPChunkVP8XTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/format/xmp/XmpWriterEdgeCasesTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/format/xmp/XmpWriterEdgeCasesTest.kt
@@ -23,7 +23,6 @@ import de.stefan_oltmann.kim.model.MetadataUpdate
 import de.stefan_oltmann.kim.model.TiffOrientation
 import de.stefan_oltmann.xmp.XMPMeta
 import de.stefan_oltmann.xmp.XMPMetaFactory
-import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.test.AfterTest
@@ -157,7 +156,7 @@ class XmpWriterEdgeCasesTest {
              * platform time zone is, so the expected string is computed
              * from that very zone and asserted exactly.
              */
-            val expected = Instant.fromEpochMilliseconds(0)
+            val expected = kotlin.time.Instant.fromEpochMilliseconds(0)
                 .toLocalDateTime(TimeZone.currentSystemDefault())
                 .toString()
 

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/model/ExifRatingTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/model/ExifRatingTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/model/GpsCoordinatesTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/model/GpsCoordinatesTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/model/MediaFormatTest.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/model/MediaFormatTest.kt
@@ -1,6 +1,6 @@
 /*
- * Copyright 2026 Ramon Bouckaert
  * Copyright 2026 Stefan Oltmann
+ * Copyright 2026 Ramon Bouckaert
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/commonTest/kotlin/de/stefan_oltmann/kim/testdata/KimTestData.kt
+++ b/src/commonTest/kotlin/de/stefan_oltmann/kim/testdata/KimTestData.kt
@@ -1,6 +1,6 @@
 /*
- * Copyright 2026 Ramon Bouckaert
  * Copyright 2026 Stefan Oltmann
+ * Copyright 2026 Ramon Bouckaert
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/jsMain/kotlin/de/stefan_oltmann/kim/common/Latin1EncodingExtensions.js.kt
+++ b/src/jsMain/kotlin/de/stefan_oltmann/kim/common/Latin1EncodingExtensions.js.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/jsMain/kotlin/de/stefan_oltmann/kim/common/ZLib.js.kt
+++ b/src/jsMain/kotlin/de/stefan_oltmann/kim/common/ZLib.js.kt
@@ -15,108 +15,16 @@
  */
 package de.stefan_oltmann.kim.common
 
-import de.stefan_oltmann.kim.output.ByteArrayByteWriter
 import org.khronos.webgl.Int8Array
 import org.khronos.webgl.Uint8Array
-
-/*
- * The input is fed in bounded slices, so the output size can be checked
- * between pushes and hostile data cannot expand to unbounded memory.
- */
-private const val INPUT_SLICE_LENGTH: Int = 64 * 1024
 
 internal actual fun compress(input: String): ByteArray =
     Pako.deflate(input).toByteArray()
 
-/*
- * Attention: Foreign JS throwables are not Exception subclasses, so the
- * boundary must catch Throwable to uphold the API contract that only
- * ImageException types escape.
- */
-internal actual fun decompress(
-    byteArray: ByteArray,
-    maxOutputByteCount: Int
-): String =
-    try {
-        decompressBounded(byteArray, maxOutputByteCount)
-    } catch (ex: ImageReadException) {
-        throw ex
-    } catch (ex: Throwable) {
-        throw ImageReadException("Failed to decompress the data.", ex)
-    }
+internal actual fun decompress(byteArray: ByteArray, maxOutputByteCount: Int): String =
+    Pako.inflate(byteArray.toUint8Array(), toStringOptions)
 
-/**
- * Feeds the input in bounded slices to pako's streaming inflate, so the
- * output size can be checked between pushes and hostile data cannot
- * expand to unbounded memory.
- *
- * The output is collected as raw bytes and decoded as a whole at the end,
- * because a multi-byte UTF-8 sequence split across two output chunks
- * would be corrupted by a per-chunk decode.
- */
-private fun decompressBounded(
-    byteArray: ByteArray,
-    maxOutputByteCount: Int
-): String {
-
-    /* An empty stream cannot be valid zlib data. */
-    if (byteArray.isEmpty())
-        throw ImageReadException("Unexpected end of compressed data.")
-
-    val inflater = Pako.Inflate()
-
-    val byteWriter = ByteArrayByteWriter()
-
-    var producedBytes = 0
-
-    /*
-     * The default onData handler collects chunks for the final result.
-     * Overriding it lets us count the output while inflating and abort
-     * immediately once hostile data exceeds the limit. The exception
-     * propagates through pako's push call up to the caller.
-     */
-    inflater.asDynamic().onData = { chunk: dynamic ->
-
-        val bytes = (chunk as Uint8Array).toByteArray()
-
-        producedBytes += bytes.size
-
-        if (producedBytes > maxOutputByteCount)
-            throw ImageReadException(
-                "Decompressed data exceeds $maxOutputByteCount bytes."
-            )
-
-        byteWriter.write(bytes)
-    }
-
-    var consumed = 0
-
-    while (consumed < byteArray.size) {
-
-        val sliceEnd = minOf(consumed + INPUT_SLICE_LENGTH, byteArray.size)
-
-        inflater.push(
-            byteArray.copyOfRange(consumed, sliceEnd).toUint8Array(),
-            sliceEnd == byteArray.size
-        )
-
-        if (inflater.err != 0)
-            throw ImageReadException(inflater.msg.ifBlank { "Failed to decompress the data." })
-
-        consumed = sliceEnd
-    }
-
-    /*
-     * A stream that ends without its final block never triggers pako's
-     * onEnd handler and leaves ended=false. Returning the partial output
-     * would silently lose data.
-     */
-    if (!inflater.ended)
-        throw ImageReadException("Unexpected end of compressed data.")
-
-    /* The output was collected through the onData handler above. */
-    return byteWriter.toByteArray().decodeToString()
-}
+private val toStringOptions: dynamic = js("({to: 'string'})")
 
 private fun Uint8Array.toByteArray(): ByteArray =
     Int8Array(buffer, byteOffset, length).unsafeCast<ByteArray>()
@@ -130,25 +38,6 @@ private fun ByteArray.toUint8Array(): Uint8Array {
 @JsModule("pako")
 @JsNonModule
 private external object Pako {
-
     fun deflate(data: String): Uint8Array
-
     fun inflate(data: Uint8Array, options: dynamic): String
-
-    /**
-     * Streaming variant of pako's inflate. The emitted output pieces are
-     * delivered through the [onData] handler, which is assigned dynamically
-     * by the decompression code.
-     */
-    @Suppress("UnusedPrivateMember") // Bound by the JS runtime.
-    class Inflate {
-
-        val ended: Boolean
-
-        val err: Int
-
-        val msg: String
-
-        fun push(data: Uint8Array, end: Boolean)
-    }
 }

--- a/src/jsMain/kotlin/de/stefan_oltmann/kim/common/ZLib.js.kt
+++ b/src/jsMain/kotlin/de/stefan_oltmann/kim/common/ZLib.js.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/jvmMain/kotlin/de/stefan_oltmann/kim/common/ZLib.jvm.kt
+++ b/src/jvmMain/kotlin/de/stefan_oltmann/kim/common/ZLib.jvm.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/jvmTest/kotlin/de/stefan_oltmann/kim/format/xmp/XmpWriterTest.kt
+++ b/src/jvmTest/kotlin/de/stefan_oltmann/kim/format/xmp/XmpWriterTest.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/ktorMain/kotlin/de/stefan_oltmann/kim/common/KotlinIoExtensions.kt
+++ b/src/ktorMain/kotlin/de/stefan_oltmann/kim/common/KotlinIoExtensions.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/ktorMain/kotlin/de/stefan_oltmann/kim/common/Latin1EncodingExtensions.ktor.kt
+++ b/src/ktorMain/kotlin/de/stefan_oltmann/kim/common/Latin1EncodingExtensions.ktor.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/ktorMain/kotlin/de/stefan_oltmann/kim/input/KtorByteReadChannelByteReader.kt
+++ b/src/ktorMain/kotlin/de/stefan_oltmann/kim/input/KtorByteReadChannelByteReader.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/posixMain/kotlin/de/stefan_oltmann/kim/Main.kt
+++ b/src/posixMain/kotlin/de/stefan_oltmann/kim/Main.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/posixMain/kotlin/de/stefan_oltmann/kim/common/PosixByteArrayReader.kt
+++ b/src/posixMain/kotlin/de/stefan_oltmann/kim/common/PosixByteArrayReader.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +19,7 @@ package de.stefan_oltmann.kim.common
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.UnsafeNumber
+import kotlinx.cinterop.convert
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.refTo
 import platform.posix.FILE
@@ -63,7 +65,7 @@ internal fun readFileAsByteArray(filePath: String): ByteArray? = memScoped {
 
         rewind(file)
 
-        val byteCount = fileSize.toInt()
+        val byteCount = fileSize.convert<Int>()
 
         val buffer = ByteArray(byteCount)
 

--- a/src/posixMain/kotlin/de/stefan_oltmann/kim/common/ZLib.posix.kt
+++ b/src/posixMain/kotlin/de/stefan_oltmann/kim/common/ZLib.posix.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +17,6 @@
 package de.stefan_oltmann.kim.common
 
 import de.stefan_oltmann.kim.output.ByteArrayByteWriter
-import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.UnsafeNumber
 import kotlinx.cinterop.alloc
@@ -24,6 +24,7 @@ import kotlinx.cinterop.convert
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.refTo
+import kotlinx.cinterop.reinterpret
 import platform.zlib.Z_DEFAULT_COMPRESSION
 import platform.zlib.Z_FINISH
 import platform.zlib.Z_NO_FLUSH
@@ -36,7 +37,6 @@ import platform.zlib.deflateInit
 import platform.zlib.inflate
 import platform.zlib.inflateEnd
 import platform.zlib.inflateInit
-import platform.zlib.uByteVar
 import platform.zlib.z_stream
 
 private const val OUTPUT_BUFFER_LENGTH = 4096
@@ -66,7 +66,7 @@ internal actual fun compress(input: String): ByteArray {
 
             /* Set the input buffer and its length. */
             if (inputBuffer.isNotEmpty())
-                stream.next_in = inputBuffer.refTo(0).getPointer(this) as CPointer<uByteVar>
+                stream.next_in = inputBuffer.refTo(0).getPointer(this).reinterpret()
             else
                 stream.next_in = null
 
@@ -74,7 +74,7 @@ internal actual fun compress(input: String): ByteArray {
 
             /* Set the output buffer and its length. */
             if (outputBuffer.isNotEmpty())
-                stream.next_out = outputBuffer.refTo(0).getPointer(this) as CPointer<uByteVar>
+                stream.next_out = outputBuffer.refTo(0).getPointer(this).reinterpret()
             else
                 stream.next_out = null
 
@@ -90,7 +90,7 @@ internal actual fun compress(input: String): ByteArray {
             val compressedDataLength = outputBufferLength - stream.avail_out
 
             /* Return the compressed data as a ByteArray. */
-            return outputBuffer.copyOf(compressedDataLength.toInt())
+            return@compress outputBuffer.copyOf(compressedDataLength.toInt())
 
         } finally {
             /* Clean up the zlib stream. */
@@ -121,7 +121,7 @@ internal actual fun decompress(
             throw ImageReadException("inflateInit failed: $inflateInitResult")
 
         /* Set the input buffer and its length. */
-        stream.next_in = byteArray.refTo(0).getPointer(this) as CPointer<uByteVar>
+        stream.next_in = byteArray.refTo(0).getPointer(this).reinterpret()
         stream.avail_in = byteArray.size.toUInt()
 
         val outputBuffer = ByteArray(OUTPUT_BUFFER_LENGTH)
@@ -139,7 +139,7 @@ internal actual fun decompress(
             while (true) {
 
                 /* Set the output buffer and its length */
-                stream.next_out = outputBuffer.refTo(0).getPointer(this) as CPointer<uByteVar>
+                stream.next_out = outputBuffer.refTo(0).getPointer(this).reinterpret()
                 stream.avail_out = OUTPUT_BUFFER_LENGTH.toUInt()
 
                 /* Decompress the data */

--- a/src/wasmMain/kotlin/de/stefan_oltmann/kim/common/Latin1EncodingExtensions.wasm.kt
+++ b/src/wasmMain/kotlin/de/stefan_oltmann/kim/common/Latin1EncodingExtensions.wasm.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/wasmMain/kotlin/de/stefan_oltmann/kim/common/ZLib.wasm.kt
+++ b/src/wasmMain/kotlin/de/stefan_oltmann/kim/common/ZLib.wasm.kt
@@ -26,6 +26,7 @@ internal actual fun compress(input: String): ByteArray =
 internal actual fun decompress(byteArray: ByteArray, maxOutputByteCount: Int): String =
     Pako.inflate(byteArray.toUint8Array(), toStringOptions)
 
+@OptIn(ExperimentalWasmJsInterop::class)
 private val toStringOptions: JsAny = js("({to: 'string'})")
 
 private fun Uint8Array.toByteArray(): ByteArray =

--- a/src/wasmMain/kotlin/de/stefan_oltmann/kim/common/ZLib.wasm.kt
+++ b/src/wasmMain/kotlin/de/stefan_oltmann/kim/common/ZLib.wasm.kt
@@ -19,118 +19,14 @@ import org.khronos.webgl.Uint8Array
 import org.khronos.webgl.get
 import org.khronos.webgl.set
 
-/*
- * The input is fed in bounded slices, so the output size can be checked
- * between pushes and hostile data cannot expand to unbounded memory.
- */
-private const val INPUT_SLICE_LENGTH: Int = 64 * 1024
-
 internal actual fun compress(input: String): ByteArray =
     Pako.deflate(input).toByteArray()
 
-/*
- * Attention: Foreign JS throwables are not Exception subclasses, so the
- * boundary must catch Throwable to uphold the API contract that only
- * ImageException types escape.
- */
 @OptIn(ExperimentalWasmJsInterop::class)
-internal actual fun decompress(
-    byteArray: ByteArray,
-    maxOutputByteCount: Int
-): String =
-    try {
-        decompressBounded(byteArray, maxOutputByteCount)
-    } catch (ex: ImageReadException) {
-        throw ex
-    } catch (ex: Throwable) {
-        throw ImageReadException("Failed to decompress the data.", ex)
-    }
+internal actual fun decompress(byteArray: ByteArray, maxOutputByteCount: Int): String =
+    Pako.inflate(byteArray.toUint8Array(), toStringOptions)
 
-/**
- * Feeds the input in bounded slices to pako's streaming inflate, so the
- * output size can be checked between pushes and hostile data cannot
- * expand to unbounded memory.
- *
- * The output is collected as raw bytes and decoded as a whole at the end,
- * because a multi-byte UTF-8 sequence split across two output chunks
- * would be corrupted by a per-chunk decode.
- */
-@OptIn(ExperimentalWasmJsInterop::class)
-private fun decompressBounded(
-    byteArray: ByteArray,
-    maxOutputByteCount: Int
-): String {
-
-    /* An empty stream cannot be valid zlib data. */
-    if (byteArray.isEmpty())
-        throw ImageReadException("Unexpected end of compressed data.")
-
-    val inflater = Inflate()
-
-    var totalOutputBytes = 0
-
-    var processedChunks = 0
-
-    var consumed = 0
-
-    while (consumed < byteArray.size) {
-
-        val sliceEnd = minOf(consumed + INPUT_SLICE_LENGTH, byteArray.size)
-
-        inflater.push(
-            byteArray.copyOfRange(consumed, sliceEnd).toUint8Array(),
-            sliceEnd == byteArray.size
-        )
-
-        if (inflater.err != 0)
-            throw ImageReadException(
-                inflater.msg?.toString()?.ifBlank { "Failed to decompress the data." }
-                    ?: "Failed to decompress the data."
-            )
-
-        /*
-         * Abort before the untrusted data grows the output beyond the
-         * limit, so it can never be allocated completely. The output of
-         * the final slice is checked through the result below.
-         */
-        while (processedChunks < inflater.chunks.length) {
-
-            val chunk = inflater.chunks[processedChunks]!!.unsafeCast<Uint8Array>()
-
-            totalOutputBytes += chunk.length
-
-            if (totalOutputBytes > maxOutputByteCount)
-                throw ImageReadException(
-                    "Decompressed data exceeds $maxOutputByteCount bytes."
-                )
-
-            processedChunks++
-        }
-
-        consumed = sliceEnd
-    }
-
-    /*
-     * A stream that ends without its final block never triggers pako's
-     * onEnd handler and leaves ended=false. Returning the partial output
-     * would silently lose data.
-     */
-    if (!inflater.ended)
-        throw ImageReadException("Unexpected end of compressed data.")
-
-    /*
-     * The flattened full output is exposed as raw bytes, since no string
-     * option was set.
-     */
-    val result = inflater.result.unsafeCast<Uint8Array>()
-
-    if (result.length > maxOutputByteCount)
-        throw ImageReadException(
-            "Decompressed data exceeds $maxOutputByteCount bytes."
-        )
-
-    return result.toByteArray().decodeToString()
-}
+private val toStringOptions: JsAny = js("({to: 'string'})")
 
 private fun Uint8Array.toByteArray(): ByteArray =
     ByteArray(length) { this[it] }
@@ -149,27 +45,4 @@ private fun ByteArray.toUint8Array(): Uint8Array {
 private external object Pako {
     fun deflate(data: String): Uint8Array
     fun inflate(data: Uint8Array, options: JsAny): String
-}
-
-/**
- * Streaming variant of pako's inflate, so decompression can be aborted
- * once the output exceeds the configured limit. The emitted output pieces
- * are collected in [chunks] as raw byte arrays.
- */
-@OptIn(ExperimentalWasmJsInterop::class)
-@Suppress("UnusedPrivateMember") // Bound by the JS runtime.
-@JsModule("pako")
-private external class Inflate {
-
-    val chunks: JsArray<JsAny>
-
-    val ended: Boolean
-
-    val err: Int
-
-    val msg: JsString?
-
-    val result: JsAny
-
-    fun push(data: Uint8Array, end: Boolean)
 }

--- a/src/wasmMain/kotlin/de/stefan_oltmann/kim/common/ZLib.wasm.kt
+++ b/src/wasmMain/kotlin/de/stefan_oltmann/kim/common/ZLib.wasm.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2026 Stefan Oltmann
  * Copyright 2025 Ashampoo GmbH & Co. KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The AI-improved solution turned out to be AI slop that didn't work in all cases. Going back to the battle-tested version.

Also enabled compiler options to treat warnings as errors and fixed the resulting issues.