### PR TITLE
Fix: Document public API used by exif-viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 
 Kim is a Kotlin Multiplatform library for reading and writing image metadata.
 
+This lib is used in production by my online [EXIF Viewer](https://stefan-oltmann.de/exif-viewer),
+[Thumbnail Fixer Pro](https://apps.microsoft.com/detail/9p9hdfltk63l),
+[Quick Metadata Remover](https://apps.microsoft.com/detail/9ngnvr157ztg)
+and [PixelSafe](https://github.com/StefanOltmann/pixelsafe).
+
 ## Features
 
 * JPG: Read & Write EXIF, IPTC & XMP

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/BoxReader.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/bmff/BoxReader.kt
@@ -64,10 +64,12 @@ public object BoxReader {
      * Reads all top-level boxes of the file completely, including the
      * image data payloads.
      *
+     * **Attention:** Must be public API as this is used by https://stefan-oltmann.de/exif-viewer
+     *
      * @param byteReader The reader as source for the bytes
      * @param offsetShift The shift to apply to the reported box offsets
      */
-    internal fun readAllBoxes(
+    public fun readAllBoxes(
         byteReader: ByteReader,
         offsetShift: Long = 0
     ): List<Box> =

--- a/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/JpegSegmentAnalyzer.kt
+++ b/src/commonMain/kotlin/de/stefan_oltmann/kim/format/jpeg/JpegSegmentAnalyzer.kt
@@ -30,20 +30,17 @@ import de.stefan_oltmann.kim.input.skipBytes
 import kotlin.jvm.JvmStatic
 
 /**
- * Algorithm to find segment offsets, types and lengths.
- *
- * This analyzer is a maintained public feature in its own right and not a
- * helper of the segment reader used for writing, so its contract is
- * documented here explicitly.
+ * Algorithm to find segment offsets, types, and lengths.
  *
  * Offsets are absolute positions from the stream start and lengths include
  * the 2 marker bytes. The SOS segment reaches to the end of the file; an
  * EOI segment is only reported when the marker is physically present, so a
  * truncated file yields exactly the segments its bytes contain.
+ *
+ * **Attention:** Must be public API as this is used by https://stefan-oltmann.de/exif-viewer
  */
 public object JpegSegmentAnalyzer {
 
-    @OptIn(ExperimentalStdlibApi::class)
     @Throws(ImageReadException::class)
     @Suppress("ComplexMethod")
     @JvmStatic
@@ -145,7 +142,7 @@ public object JpegSegmentAnalyzer {
 
         } while (true)
 
-        return segmentInfos
+        return@findSegmentInfos segmentInfos
     }
 
     /**


### PR DESCRIPTION
The API visibility was narrowed by accident. My EXIF Viewer needs it.